### PR TITLE
Remove pnpm from deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,14 +14,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Download pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 7.13.4
-
-      - name: Install node_modules
-        run: pnpm install
-
       - name: Build
         run: bazel build //util:package
 


### PR DESCRIPTION
Now that the Bazel dependencies are correct we should not longer have to use pnpm to install `node_modules`.